### PR TITLE
Pre-deploy Polishes

### DIFF
--- a/src/app/components/admin-features/admin-features.component.html
+++ b/src/app/components/admin-features/admin-features.component.html
@@ -1,4 +1,23 @@
 <div class="admin-features-container">
+  <mat-card class="promoted-route-card">
+    <mat-card-header>
+      <mat-card-title>Promoted Route</mat-card-title>
+      <mat-card-subtitle>The page users see by default after signing in</mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <mat-form-field class="w-100">
+        <mat-label>Default Landing Page</mat-label>
+        <mat-select [(value)]="promotedRoute" (selectionChange)="onPromotedRouteChange($event.value)">
+          <mat-option value="">-- Select --</mat-option>
+          <mat-option *ngFor="let feature of featureOptions" [value]="feature.route">
+            {{ feature.label }} ({{ feature.route }})
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </mat-card-content>
+  </mat-card>
+
   <mat-card class="features-card">
     <mat-card-header>
       <mat-card-title>Feature Flags</mat-card-title>

--- a/src/app/components/admin-features/admin-features.component.scss
+++ b/src/app/components/admin-features/admin-features.component.scss
@@ -4,6 +4,28 @@
   margin: 0 auto;
 }
 
+.promoted-route-card {
+  margin-bottom: 24px;
+
+  mat-card-header {
+    margin-bottom: 16px;
+  }
+
+  mat-card-title {
+    font-size: 20px;
+    font-weight: 500;
+  }
+
+  mat-card-subtitle {
+    color: rgba(0, 0, 0, 0.54);
+  }
+
+  .w-100 {
+    width: 100%;
+    margin-top: 8px;
+  }
+}
+
 .features-card {
   mat-card-header {
     margin-bottom: 16px;

--- a/src/app/components/admin-features/admin-features.component.ts
+++ b/src/app/components/admin-features/admin-features.component.ts
@@ -11,12 +11,18 @@ import { FEATURES, FeatureConfig } from 'src/app/config/feature-config';
 export class AdminFeaturesComponent implements OnInit {
   flagsMap: Record<string, FeatureFlag | null> = {};
   featureDefs: FeatureConfig[] = FEATURES;
+  promotedRoute: string = '';
+  featureOptions = FEATURES;
 
   constructor(private featureFlagsService: FeatureFlagsService) { }
 
   ngOnInit(): void {
     this.featureFlagsService.getAllFeatureFlags().subscribe(flagsMap => {
       this.flagsMap = flagsMap;
+    });
+
+    this.featureFlagsService.getPromotedRoute().subscribe((data: any) => {
+      this.promotedRoute = data?.route || '';
     });
   }
 
@@ -27,5 +33,9 @@ export class AdminFeaturesComponent implements OnInit {
 
   onToggle(featureId: string, enabled: boolean): void {
     this.featureFlagsService.setFeatureFlag(featureId, enabled);
+  }
+
+  onPromotedRouteChange(route: string): void {
+    this.featureFlagsService.setPromotedRoute(route);
   }
 }

--- a/src/app/components/admin/admin.component.html
+++ b/src/app/components/admin/admin.component.html
@@ -6,12 +6,6 @@
       </a>
     </div>
     <ul class="sidebar-nav">
-      <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
-        <a routerLink="/admin">
-          <mat-icon>home</mat-icon>
-          <span>Overview</span>
-        </a>
-      </li>
       <li routerLinkActive="active">
         <a routerLink="/admin/users">
           <mat-icon>people</mat-icon>

--- a/src/app/components/calendar-cell/calendar-cell.component.scss
+++ b/src/app/components/calendar-cell/calendar-cell.component.scss
@@ -74,7 +74,6 @@
   border-radius: 4px;
   text-align: left;
   line-height: 1.1;
-  width: 100%;
 }
 
 .event-title-link:hover,

--- a/src/app/components/calendar-view/calendar-view.component.scss
+++ b/src/app/components/calendar-view/calendar-view.component.scss
@@ -43,7 +43,7 @@
   display: block;
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1350px) {
   .calendar-scroll-container {
     overflow-x: hidden;
   }
@@ -72,15 +72,15 @@
   background: #fff;
   border-radius: 16px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.07), 0 2px 4px rgba(0, 0, 0, 0.06);
-  overflow: hidden;
-  min-width: 1000px;
+  overflow: visible;
+  min-width: 700px;
   width: max-content;
 }
 
 @media (max-width: 768px) {
   .calendar-month-view-container {
     border-radius: 8px;
-    min-width: 1000px;
+    min-width: 700px;
     width: max-content;
   }
 
@@ -96,7 +96,7 @@
 
   .calendar-month-view-container {
     border-radius: 8px;
-    min-width: 1000px;
+    min-width: 700px;
     width: max-content;
   }
 

--- a/src/app/components/calendar/calendar.component.scss
+++ b/src/app/components/calendar/calendar.component.scss
@@ -4,6 +4,7 @@
   min-height: 100vh;
   box-sizing: border-box;
   position: relative;
+  overflow-x: hidden;
 }
 
 .calendar-toolbar {
@@ -239,6 +240,7 @@
 .calendar-view-component {
   margin: auto;
   width: 100%;
+  overflow-x: auto;
 }
 
 @media (max-width: 600px) {

--- a/src/app/components/expression-edit/expression-edit.component.html
+++ b/src/app/components/expression-edit/expression-edit.component.html
@@ -1,181 +1,54 @@
-<div
-  class="chat-edit-component"
-  *ngIf="user"
->
-  <div
-    class="d-flex justify-content-center"
-    *ngIf="isSaving"
-  >
-    <mat-spinner></mat-spinner>
-  </div>
-  <div
-    class="row mb-4 message-card-content-container"
-    *ngIf="!isSaving"
-    [ngStyle]="{ 'margin-left.px': message.replyLevel * 25 }"
-  >
-    <div class="col-2 col-md-1 message-tools-container">
-      <div class="d-flex justify-content-center flex-column mt-2">
-        <div
-          class="mb-3 message-button"
-          *ngIf="message.isSaved"
-          [ngStyle]="{
-            color: highlights.trash === true ? '#FF9800' : '#F44336'
-          }"
-        >
-          <div *ngIf="!message.isDeleted">
-            <div
-              class="d-flex flex-row justify-content-center"
-              (mouseover)="highlightElement('trash', true)"
-              (mouseleave)="highlightElement('trash', false)"
-              (click)="deleteMessage()"
-            >
-              <span class="fa fa-trash fa-2x"></span>
-            </div>
-            <span class="message-button-label d-flex justify-content-center"
-              >Delete</span
-            >
-          </div>
-          <div *ngIf="message.isDeleted">
-            <div
-              class="d-flex flex-row justify-content-center"
-              (mouseover)="highlightElement('trash', true)"
-              (mouseleave)="highlightElement('trash', false)"
-              (click)="restoreMessage()"
-            >
-              <span class="fa fa-undo fa-2x"></span>
-            </div>
-            <span class="message-button-label d-flex justify-content-center"
-              >Restore</span
-            >
-          </div>
-        </div>
-        <div
-          class="mb-3 message-button chat-edit-button-cancel"
-          [ngStyle]="{
-            color: highlights.cancel === true ? '#FF9800' : '#F44336'
-          }"
-        >
-          <div
-            class="d-flex flex-row justify-content-center"
-            (mouseover)="highlightElement('cancel', true)"
-            (mouseleave)="highlightElement('cancel', false)"
-            (click)="cancelEdit()"
-          >
-            <span class="fa fa-ban fa-2x"></span>
-          </div>
-          <span class="message-button-label d-flex justify-content-center"
-            >Cancel</span
-          >
-        </div>
-        <div
-          class="mb-3 message-button chat-edit-button-send"
-          [ngStyle]="{
-            color: highlights.send === true ? '#FF9800' : '#F44336'
-          }"
-        >
-          <div
-            class="d-flex flex-row justify-content-center"
-            (mouseover)="highlightElement('send', true)"
-            (mouseleave)="highlightElement('send', false)"
-            (click)="saveMessage(message)"
-          >
-            <span class="fa fa-check fa-2x"></span>
-          </div>
-          <span class="message-button-label d-flex justify-content-center"
-            >Save</span
-          >
-        </div>
-        <div
-          class="mb-3 chat-edit-button-sticky"
-          *ngIf="shouldShowStickyButton"
-          [ngStyle]="{
-            color: highlights.sticky === true ? '#FF9800' : '#F44336'
-          }"
-        >
-          <div
-            class="d-flex flex-row justify-content-center"
-            (mouseover)="highlightElement('sticky', true)"
-            (mouseleave)="highlightElement('sticky', false)"
-          >
-            <mat-checkbox [(ngModel)]="message.isSticky"></mat-checkbox>
-          </div>
-          <span class="message-button-label d-flex justify-content-center"
-            >Sticky</span
-          >
-        </div>
-      </div>
+<div class="expression-edit" *ngIf="user && !isSaving">
+  <div class="expression-edit-form">
+    <div class="form-row">
+      <mat-form-field>
+        <mat-label>Expression</mat-label>
+        <input
+          matInput
+          [(ngModel)]="message.title"
+        />
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Attribution</mat-label>
+        <input
+          matInput
+          [(ngModel)]="message.attribution"
+        />
+      </mat-form-field>
     </div>
-    <mat-divider
-      class="message-controls-divider-vertical"
-      [vertical]="true"
-    ></mat-divider>
-    <div class="message-edit-message-form-container col-9">
-      <mat-card-content>
-        <div
-          class="message-title-input-container"
-          *ngIf="!message.isReply"
-        >
-          <mat-form-field class="w-100">
-            <input
-              matInput
-              class="chat-edit-input-title"
-              placeholder="Expression"
-              [(ngModel)]="message.title"
-            />
-          </mat-form-field>
-          <mat-form-field class="w-100">
-            <input
-              matInput
-              class="chat-edit-input-author"
-              placeholder="Attribution"
-              [(ngModel)]="message.attribution"
-            />
-          </mat-form-field>
-          <mat-form-field class="w-100">
-            <input
-              matInput
-              class="chat-edit-input-author"
-              placeholder="Author"
-              [(ngModel)]="message.authorName"
-            />
-          </mat-form-field>
-          <mat-form-field class="w-100">
-            <input
-              matInput
-              class="chat-edit-input-author"
-              placeholder="Year Written"
-              [(ngModel)]="message.yearWritten"
-            />
-          </mat-form-field>
-        </div>
-        <mat-form-field class="w-100">
-          <textarea
-            matInput
-            class="message-edit-input-body"
-            placeholder="Description"
-            cdkTextareaAutosize
-            #autosize="cdkTextareaAutosize"
-            #input
-            [(ngModel)]="message.body"
-          ></textarea>
-        </mat-form-field>
-      </mat-card-content>
+    <div class="form-row">
+      <mat-form-field>
+        <mat-label>Author</mat-label>
+        <input
+          matInput
+          [(ngModel)]="message.authorName"
+        />
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Year Written</mat-label>
+        <input
+          matInput
+          [(ngModel)]="message.yearWritten"
+        />
+      </mat-form-field>
+    </div>
+    <mat-form-field class="w-100">
+      <mat-label>Description</mat-label>
+      <textarea
+        matInput
+        cdkTextareaAutosize
+        #autosize="cdkTextareaAutosize"
+        [(ngModel)]="message.body"
+      ></textarea>
+    </mat-form-field>
+
+    <div class="form-actions">
+      <button mat-button (click)="cancelEdit()">Cancel</button>
+      <button mat-flat-button color="primary" (click)="saveMessage(message)">Save</button>
     </div>
   </div>
-  <mat-card-content *ngFor="let reply of message.replies">
-    <app-chat-view
-      *ngIf="!reply.isEditable"
-      [message]="reply"
-      [parent]="message"
-      (updateParentEvent)="updateParent()"
-    >
-    </app-chat-view>
-    <app-chat-edit
-      *ngIf="reply.isEditable"
-      [message]="reply"
-      [parent]="message"
-      (updateParentEvent)="updateParent()"
-    >
-    </app-chat-edit>
-  </mat-card-content>
+</div>
+
+<div class="expression-edit-saving" *ngIf="isSaving">
+  <mat-spinner></mat-spinner>
 </div>

--- a/src/app/components/expression-edit/expression-edit.component.scss
+++ b/src/app/components/expression-edit/expression-edit.component.scss
@@ -1,1 +1,33 @@
-@import "src/app/components/message-edit/message-edit.component.scss";
+.expression-edit {
+  padding: 20px 24px;
+}
+
+.expression-edit-form {
+  max-width: 600px;
+
+  .form-row {
+    display: flex;
+    gap: 16px;
+
+    mat-form-field {
+      flex: 1;
+    }
+  }
+
+  mat-form-field {
+    margin-bottom: 8px;
+  }
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.expression-edit-saving {
+  display: flex;
+  justify-content: center;
+  padding: 40px;
+}

--- a/src/app/components/expression-view/expression-view.component.html
+++ b/src/app/components/expression-view/expression-view.component.html
@@ -1,117 +1,43 @@
-<div
-  class="row message-card-content-container"
-  [ngStyle]="{ 'margin-left.px': message.replyLevel * 25 }"
->
-  <div class="col-3 col-sm-2 col-lg-1 message-tools-container">
-    <div
-      class="mb-3 message-button"
-      [ngStyle]="{ color: highlights.reply === true ? '#FF9800' : '#F44336' }"
-    >
-      <div
-        class="d-flex flex-row justify-content-center"
-        (mouseover)="highlightElement('reply', true)"
-        (mouseleave)="highlightElement('reply', false)"
-        (click)="replyMessage()"
-      >
-        <span class="fa fa-reply-all fa-2x"></span>
-      </div>
-      <span class="message-button-label d-flex justify-content-center"
-        >Comment</span
-      >
+<div class="expression-card" *ngIf="!message.isDeleted">
+  <div class="expression-content">
+    <div class="expression-header">
+      <h3 class="expression-title">"{{ message.title }}"</h3>
+      <span class="expression-attribution">- {{ message.attribution }}</span>
     </div>
-    <div
-      class="message-button"
-      *ngIf="
-        message.authorId === user.id || (user && user.roles && user.roles.admin)
-      "
-      [ngStyle]="{ color: highlights.edit === true ? '#FF9800' : '#F44336' }"
-    >
-      <div
-        class="d-flex flex-row justify-content-center"
-        (mouseover)="highlightElement('edit', true)"
-        (mouseleave)="highlightElement('edit', false)"
-        (click)="editMessage()"
-      >
-        <span class="fa fa-pencil fa-2x"></span>
-      </div>
-      <span class="message-button-label d-flex justify-content-center"
-        >Edit</span
-      >
-    </div>
-  </div>
-  <mat-divider
-    class="message-controls-divider-vertical"
-    [vertical]="true"
-  ></mat-divider>
-  <div class="message-view-container col-7 col-sm-8 col-lg-10">
-    <mat-card-content
-      class="message-view-deleted-container col-9"
-      *ngIf="message.isDeleted"
-    >
-      <mat-card-title>
-        <mat-card-subtitle class="chat-message-author-name">
-          <i>This message was deleted.</i>
-        </mat-card-subtitle>
-      </mat-card-title>
-    </mat-card-content>
-    <mat-card-content *ngIf="!message.isDeleted">
-      <mat-card-title
-        class="expression-title"
-        *ngIf="!message.isReply"
-      >
-        "{{ message.title }}"
-      </mat-card-title>
-      <mat-card-subtitle class="expression-attribution">
-        - {{ message.attribution }}
-      </mat-card-subtitle>
-      <div
-        class="expression-body"
-        [innerHTML]="message.body"
-      ></div>
-      <mat-card-subtitle class="expression-attribution expression-author">
-        - {{ message.authorName }}, {{ message.yearWritten }}
-      </mat-card-subtitle>
-      <br />
+
+    <div class="expression-body" [innerHTML]="message.body"></div>
+
+    <div class="expression-meta">
+      <span class="expression-author">- {{ message.authorName }}, {{ message.yearWritten }}</span>
       <img
-        mat-card-image
-        src="{{ message.attachmentUrl }}"
-        class="massage-attachment-image"
         *ngIf="getAttachmentType(message) === 'photo'"
+        [src]="message.attachmentUrl"
+        class="expression-image"
       />
       <a
-        mat-button
-        [href]="message.attachmentUrl"
-        class="message-view-attachment-button"
-        target="_blank"
         *ngIf="getAttachmentType(message) === 'document'"
-      >
-        View Attachment
-      </a>
-      <a
-        mae-button
         [href]="message.attachmentUrl"
-        class="message-view-attachment-button"
-        download
-        *ngIf="getAttachmentType(message) === 'other'"
+        class="expression-attachment-link"
+        target="_blank"
       >
-        Download Attachment
+        <mat-icon>attach_file</mat-icon> View Attachment
       </a>
-    </mat-card-content>
+    </div>
+  </div>
+
+  <div
+    class="expression-actions"
+    *ngIf="user && user.roles && user.roles.admin"
+  >
+    <button
+      mat-icon-button
+      (click)="editMessage()"
+    >
+      <mat-icon>edit</mat-icon>
+    </button>
   </div>
 </div>
-<mat-card-content *ngFor="let reply of message.replies">
-  <app-chat-view
-    *ngIf="!reply.isEditable"
-    [message]="reply"
-    [parent]="message"
-    (updateParentEvent)="updateParent()"
-  >
-  </app-chat-view>
-  <app-chat-edit
-    *ngIf="reply.isEditable"
-    [message]="reply"
-    [parent]="message"
-    (updateParentEvent)="updateParent()"
-  >
-  </app-chat-edit>
-</mat-card-content>
+
+<div class="expression-card expression-deleted" *ngIf="message.isDeleted">
+  <span class="deleted-text">This expression was deleted.</span>
+</div>

--- a/src/app/components/expression-view/expression-view.component.scss
+++ b/src/app/components/expression-view/expression-view.component.scss
@@ -1,17 +1,117 @@
-@import "src/app/components/message-view/message-view.component.scss";
-@import "src/app/components/expressions/expressions.component.scss";
+.expression-card {
+  display: flex;
+  align-items: stretch;
+  padding: 0;
+  border-bottom: 1px solid #f0f0f0;
+  transition: box-shadow 0.2s;
+
+  &:hover {
+    box-shadow: 0 4px 12px rgba(45, 90, 39, 0.12);
+
+    .expression-actions {
+      opacity: 1;
+    }
+  }
+}
+
+.expression-content {
+  flex: 1;
+  padding: 20px 24px;
+  border-left: 4px solid #2d5a27;
+}
+
+.expression-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+
+  @media (max-width: 576px) {
+    flex-direction: column;
+    gap: 4px;
+  }
+}
 
 .expression-title {
   font-style: italic;
-  margin-bottom: 0;
-}
-
-.expression-author {
-  margin-top: 0.15em;
-  margin-left: 0.5em;
-  font-size: 0.9em;
+  font-size: 1.2em;
+  font-weight: 600;
+  color: #1e3c1a;
+  margin: 0;
 }
 
 .expression-attribution {
-  margin-left: 0.5em;
+  font-size: 0.9em;
+  color: #6b8e6b;
+  font-style: italic;
+}
+
+.expression-body {
+  font-size: 0.95em;
+  color: #444;
+  line-height: 1.6;
+  margin-bottom: 14px;
+  padding-left: 2px;
+}
+
+.expression-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.expression-author {
+  font-size: 0.8em;
+  color: #8b7355;
+  font-weight: 500;
+}
+
+.expression-image {
+  max-width: 200px;
+  border-radius: 8px;
+  margin-top: 8px;
+}
+
+.expression-attachment-link {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8em;
+  color: #757575;
+  text-decoration: none;
+
+  mat-icon {
+    font-size: 1em;
+    width: 1em;
+    height: 1em;
+  }
+
+  &:hover {
+    color: #333;
+  }
+}
+
+.expression-actions {
+  opacity: 0;
+  transition: opacity 0.15s;
+
+  button {
+    color: #9e9e9e;
+
+    &:hover {
+      color: #616161;
+    }
+  }
+}
+
+.expression-deleted {
+  padding: 16px 24px;
+
+  .deleted-text {
+    font-size: 0.9em;
+    color: #999;
+    font-style: italic;
+  }
 }

--- a/src/app/components/expressions/expressions.component.html
+++ b/src/app/components/expressions/expressions.component.html
@@ -1,115 +1,101 @@
 <div class="expressions-component m-3">
-  <div class="d-flex flex-column align-items-center align-items-md-start row">
-    <div
-      class="w-100 d-flex justify-content-center justify-content-md-end"
-      *ngIf="user && user.roles && user.roles.admin"
-    >
-      <button
-        mat-button
-        (click)="onCreate()"
-      >
-        <span class="d-flex align-items-center justify-content-center">
-          <mat-icon>add</mat-icon>
-          <span>Create Expression</span>
-        </span>
-      </button>
-    </div>
-
-    <div class="d-flex align-items-center row">
-      <mat-form-field class="col-md-4 col-lg-3 col-xl-2">
-        <mat-label>Search</mat-label>
-        <input
-          matInput
-          type="text"
-          [(ngModel)]="sortSettings.activeFilterQuery"
-          (input)="onFilterQueryChange($event.target.value)"
-        />
-        <button
-          *ngIf="sortSettings.activeFilterQuery"
-          matSuffix
-          mat-icon-button
-          aria-label="Clear"
-          (click)="onFilterQueryChange('')"
-        >
-          <mat-icon>close</mat-icon>
-        </button>
-      </mat-form-field>
-      <div
-        class="d-flex col-md-5 col-xl-3 justify-content-center justify-content-md-start"
-      >
-        <div
-          class="d-inline-flex"
-          style="max-width: 14em row"
-        >
-          <button
-            class="col-8"
-            mat-button
-            [matMenuTriggerFor]="menu"
-          >
-            Sort By: {{ sortSettings.activeSortProperty?.title }}
-          </button>
-          <button
-            class="col-2"
-            mat-button
-            (click)="reverseSortDirection()"
-          >
-            <mat-icon *ngIf="!sortSettings.isSortDescending()"
-              >arrow_drop_up</mat-icon
-            >
-            <mat-icon *ngIf="sortSettings.isSortDescending()"
-              >arrow_drop_down</mat-icon
-            >
-          </button>
-        </div>
-      </div>
-      <mat-menu #menu="matMenu">
-        <button
-          mat-menu-item
-          *ngFor="let sortProperty of sortSettings.sortableProperties"
-          r
-          (click)="setSortProperty(sortProperty)"
-        >
-          {{ sortProperty.title }}
-        </button>
-      </mat-menu>
-    </div>
-
-    <div
-      class="mt-3 d-flex justify-content-center justify-content-md-start"
-      *ngIf="shouldDisplayShowAllButton()"
-    >
-      <button
-        class="create-expression-button"
-        mat-raised-button
-        color="warn"
-        (click)="onShowAll()"
-      >
-        <span class="ml-2">Show All</span>
-      </button>
-    </div>
-  </div>
-
   <div class="expressions-header-container">
     <div class="expressions-header">
       {{ headerQuoteText }}
     </div>
-
     <div class="expressions-attribution">{{ headerAttributionText }}</div>
   </div>
 
-  <div
-    class="w-100 d-flex justify-content-center"
-    *ngIf="isLoading"
-  >
-    <mat-spinner></mat-spinner>
+  <div class="expressions-controls">
+    <mat-form-field class="search-field">
+      <mat-label><mat-icon>search</mat-icon> Search</mat-label>
+      <input
+        matInput
+        type="text"
+        [(ngModel)]="sortSettings.activeFilterQuery"
+        (input)="onFilterQueryChange($event.target.value)"
+      />
+      <button
+        *ngIf="sortSettings.activeFilterQuery"
+        matSuffix
+        mat-icon-button
+        aria-label="Clear"
+        (click)="onFilterQueryChange('')"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+
+    <div class="sort-controls">
+      <span class="sort-label">Sort:</span>
+      <button
+        class="sort-button"
+        mat-button
+        (click)="reverseSortDirection()"
+      >
+        {{ sortSettings.activeSortProperty?.title }}
+        <mat-icon>{{ sortSettings.isSortDescending() ? 'arrow_upward' : 'arrow_downward' }}</mat-icon>
+      </button>
+      <button
+        class="sort-menu-trigger"
+        mat-icon-button
+        [matMenuTriggerFor]="sortMenu"
+      >
+        <mat-icon>expand_more</mat-icon>
+      </button>
+    </div>
+
+    <div
+      class="create-expression"
+      *ngIf="user && user.roles && user.roles.admin"
+    >
+      <button mat-button class="create-expression-button" (click)="onCreate()">
+        <mat-icon>add</mat-icon>
+        Create Expression
+      </button>
+    </div>
+
+    <button
+      class="show-all-button"
+      *ngIf="shouldDisplayShowAllButton()"
+      mat-button
+      (click)="onShowAll()"
+    >
+      Show All
+    </button>
   </div>
 
-  <div
-    class="expressions-container d-flex justify-content-center row"
-    *ngIf="!isLoading"
-  >
-    <mat-card
-      class="message-card-container mat-elevation-z6 mt-4 col-lg-11 col-xl-7"
+  <mat-menu #sortMenu="matMenu">
+    <button
+      mat-menu-item
+      *ngFor="let sortProperty of sortSettings.sortableProperties"
+      (click)="setSortProperty(sortProperty)"
+    >
+      {{ sortProperty.title }}
+    </button>
+  </mat-menu>
+
+  <div class="expressions-skeleton" *ngIf="isLoading">
+    <div class="skeleton-card" *ngFor="let i of [1,2,3]">
+      <div class="skeleton-content">
+        <div class="skeleton-header">
+          <div class="skeleton-line skeleton-title"></div>
+          <div class="skeleton-line skeleton-attribution"></div>
+        </div>
+        <div class="skeleton-body">
+          <div class="skeleton-line skeleton-text"></div>
+          <div class="skeleton-line skeleton-text short"></div>
+        </div>
+        <div class="skeleton-meta">
+          <div class="skeleton-line skeleton-author"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="expressions-list" *ngIf="!isLoading">
+    <div
+      class="expression-card-wrapper"
       *ngFor="let expression of displayedItems"
     >
       <app-expression-view
@@ -117,7 +103,6 @@
         [message]="expression"
         [parent]="expression"
         (updateParentEvent)="updateMessages($event)"
-        (cancelEditEvent)="cancelEdit($event)"
       >
       </app-expression-view>
       <app-expression-edit
@@ -128,6 +113,6 @@
         (cancelEditEvent)="cancelEdit($event)"
       >
       </app-expression-edit>
-    </mat-card>
+    </div>
   </div>
 </div>

--- a/src/app/components/expressions/expressions.component.scss
+++ b/src/app/components/expressions/expressions.component.scss
@@ -1,18 +1,226 @@
-@import 'src/app/components/message/message.component.scss';
+.expressions-component {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px 16px;
+}
 
 .expressions-header-container {
-  margin: 0 2em;
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #eee;
 }
 
 .expressions-header {
-  color: #616161;
-  font-size: 1.1em;
+  color: #757575;
+  font-size: 0.85em;
   font-style: italic;
 }
 
 .expressions-attribution {
+  color: #9e9e9e;
+  font-size: 0.75em;
+  margin-top: 0.2em;
+}
+
+.expressions-controls {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+.search-field {
+  min-width: 200px;
+
+  .mat-mdc-form-field-flex {
+    height: 40px;
+  }
+
+  .mdc-text-field--outlined {
+    --mdc-outlined-text-field-container-shape: 8px;
+  }
+
+  .mat-mdc-form-field-subscript-wrapper {
+    display: none;
+  }
+
+  mat-label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.9em;
+
+    mat-icon {
+      font-size: 1em;
+      width: 1em;
+      height: 1em;
+      color: #9e9e9e;
+    }
+  }
+}
+
+.sort-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
+}
+
+.sort-label {
+  font-size: 0.85em;
+  color: #757575;
+  margin-right: 0.25em;
+}
+
+.sort-button {
+  font-size: 0.85em;
   color: #616161;
-  font-size: 0.9em;
-  margin-left: 2.5em;
-  margin-top: 0.25em;
+  letter-spacing: 0.02em;
+  padding: 0 0.5em;
+  min-width: unset;
+
+  mat-icon {
+    font-size: 1em;
+    width: 1em;
+    height: 1em;
+    margin-left: 0.2em;
+  }
+}
+
+.sort-menu-trigger {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  mat-icon {
+    font-size: 1.1em;
+    color: #9e9e9e;
+  }
+}
+
+.create-expression {
+  margin-left: auto;
+
+  .create-expression-button {
+    border-radius: 8px;
+    background: #f1f5f9;
+    color: #4a5568;
+    width: auto;
+    height: 36px;
+
+    &:hover {
+      background: #e2e8f0;
+      color: #2d3748;
+    }
+
+    &:active {
+      background: #cbd5e0;
+      transform: scale(0.98);
+    }
+  }
+}
+
+.show-all-button {
+  font-size: 0.8em;
+  color: #757575;
+}
+
+.expressions-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.expression-card-wrapper {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  margin-bottom: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  transition: box-shadow 0.2s, transform 0.15s;
+
+  &:hover {
+    box-shadow: 0 6px 20px rgba(45, 90, 39, 0.14);
+    border-color: #b8d4b8;
+    transform: translateY(-1px);
+  }
+}
+
+.expressions-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skeleton-card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 0;
+  overflow: hidden;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+
+  .skeleton-content {
+    padding: 20px 24px;
+    border-left: 4px solid #c8d8c8;
+  }
+
+  .skeleton-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .skeleton-body {
+    margin-bottom: 12px;
+  }
+
+  .skeleton-meta {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.skeleton-line {
+  background: linear-gradient(90deg, #f0f0f0 25%, #e8e8e8 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 4px;
+}
+
+.skeleton-title {
+  width: 200px;
+  height: 20px;
+}
+
+.skeleton-attribution {
+  width: 120px;
+  height: 16px;
+}
+
+.skeleton-text {
+  width: 100%;
+  height: 14px;
+  margin-bottom: 8px;
+
+  &.short {
+    width: 60%;
+  }
+}
+
+.skeleton-author {
+  width: 140px;
+  height: 12px;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }

--- a/src/app/components/expressions/expressions.component.ts
+++ b/src/app/components/expressions/expressions.component.ts
@@ -73,10 +73,12 @@ export class ExpressionsComponent extends MessageComponent implements OnInit {
   }
 
   setSortProperty(activeSortProperty: SortProperty) {
-    if (this.sortSettings.activeSortProperty === activeSortProperty)
+    const isSameProperty = this.sortSettings.activeSortProperty === activeSortProperty;
+    if (isSameProperty) {
       this.sortSettings.reverseSortDirection();
-
-    this.sortSettings.activeSortProperty = activeSortProperty;
+    } else {
+      this.sortSettings.activeSortProperty = activeSortProperty;
+    }
 
     const shouldResort =
       this.sortSettings.activeSortProperty !==
@@ -101,5 +103,13 @@ export class ExpressionsComponent extends MessageComponent implements OnInit {
     this.routingService.clearQueryParams();
     this.sortSettings.activeFilterParams = {};
     this.displayedItems = this.sortSettings.getItemsToDisplay(this.allItems);
+  }
+
+  cancelEdit(expression: Expression) {
+    expression.isEditable = false;
+    this.displayedItems = this.sortSettings.getItemsToDisplay(
+      this.allItems,
+      false,
+    );
   }
 }

--- a/src/app/components/media-explorer/media-explorer.component.html
+++ b/src/app/components/media-explorer/media-explorer.component.html
@@ -5,28 +5,26 @@
       *ngIf="selectedMedia?.id"
     >
       <div
-        class="media-explorer-actions-container row justify-content-center row"
+        class="media-explorer-actions-container"
       >
         <button
-          mat-button
-          class="m-1 media-explorer-action-button col-5"
+          mat-stroked-button
+          class="media-explorer-action-button"
           *ngIf="shouldShowDownloadButton()"
           matTooltip="Downloads the selected media to a file"
           (click)="downloadSelectedMedia()"
         >
-          <mat-icon class="media-explorer-action-button-icon"
-            >download</mat-icon
-          >
+          <mat-icon>download</mat-icon>
           <span>Download</span>
         </button>
         <button
-          mat-button
-          class="m-1 media-explorer-action-button col-5"
+          mat-stroked-button
+          class="media-explorer-action-button"
           *ngIf="shouldShowShareableLinkButton()"
           matTooltip="Copies a shareable link to your clipboard"
           (click)="onGetShareableLink()"
         >
-          <mat-icon class="media-explorer-action-button-icon">share</mat-icon>
+          <mat-icon>share</mat-icon>
           <span>Share</span>
         </button>
       </div>

--- a/src/app/components/media-explorer/media-explorer.component.scss
+++ b/src/app/components/media-explorer/media-explorer.component.scss
@@ -6,11 +6,49 @@
   padding: 0;
 }
 
+.media-explorer-player-container {
+  padding: 16px;
+}
+
 .media-explorer-actions-container {
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 12px;
+  margin-bottom: 12px;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+
+.media-explorer-action-button {
+  border-radius: 8px;
+  background: transparent;
+  color: #4a5568;
+  min-width: 120px;
+  height: 36px;
+  border: 1px solid #d0d5dc;
+
+  &:hover {
+    background: #f7f9fc;
+    border-color: #b8c0cc;
+    color: #2d3748;
+  }
+
+  &:active {
+    background: #e8ecf0;
+    transform: scale(0.98);
+  }
+
+  .mat-icon {
+    margin-right: 0.4em;
+    vertical-align: middle;
+  }
 }
 
 .media-explorer-action-button-icon {
   margin-right: 0.5em;
+  font-size: 1.1em;
+}
+
+.media-list-container {
+  border-left: 1px solid #eee;
+  padding-left: 0;
 }

--- a/src/app/components/media-list/media-list.component.html
+++ b/src/app/components/media-list/media-list.component.html
@@ -4,7 +4,7 @@
       class="media-list-filters-input"
       appearance="standard"
     >
-      <mat-label>Search</mat-label>
+      <mat-label><mat-icon>search</mat-icon> Search</mat-label>
       <input
         matInput
         name="media-list-filters-input-search-query"
@@ -27,46 +27,31 @@
     *ngFor="let media of filteredMedia"
   >
     <button
-      mat-button
-      class="mb-3 col-12 col-md-12 col-lg-12"
+      class="media-list-item"
       *ngIf="shouldDisplayMedia(media)"
       (click)="onMediaSelect(media)"
     >
-      <div class="row">
-        <div class="col-4 imageContainer">
-          <div class="d-flex flex-column justify-content-center h-100">
-            <mat-icon
-              class="media-list-placeholder-icon"
-              [hidden]="media.isIconLoaded"
-            >
-              {{ getPlaceholderName(media.type) }}
-            </mat-icon>
-          </div>
-          <div class="imageCenterer">
-            <img
-              [src]="media.urls.icon"
-              (load)="onImageLoaded(media)"
-              [hidden]="!media.isIconLoaded"
-            />
-          </div>
+      <div class="imageContainer">
+        <mat-icon
+          class="media-list-placeholder-icon"
+          [hidden]="media.isIconLoaded"
+        >
+          {{ getPlaceholderName(media.type) }}
+        </mat-icon>
+        <div class="imageCenterer">
+          <img
+            [src]="media.urls.icon"
+            (load)="onImageLoaded(media)"
+            [hidden]="!media.isIconLoaded"
+          />
         </div>
-        <div class="col-8 justify-content-start">
-          <div class="media-details-name">
-            {{ media.title }}
-          </div>
-          <div class="media-details-artist">
-            {{ media.artist }}
-          </div>
-          <div class="media-details-location">
-            {{ media.location }}
-          </div>
-          <div class="media-details-date">
-            {{ media.date }}
-          </div>
-          <div class="media-details-duration">
-            {{ media.duration }}
-          </div>
-        </div>
+      </div>
+      <div class="media-details">
+        <div class="media-details-name">{{ media.title }}</div>
+        <div class="media-details-artist">{{ media.artist }}</div>
+        <div class="media-details-location">{{ media.location }}</div>
+        <div class="media-details-date">{{ media.date }}</div>
+        <span class="media-details-duration">{{ media.duration }}</span>
       </div>
     </button>
   </div>

--- a/src/app/components/media-list/media-list.component.scss
+++ b/src/app/components/media-list/media-list.component.scss
@@ -1,29 +1,69 @@
 .media-list-container {
   overflow: hidden;
-  margin: 1em;
+  margin: 0;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.media-search-input-container {
-  margin-bottom: -0.5em;
+.media-list-filters-container {
+  margin-bottom: 16px;
+  padding: 0 4px;
+}
+
+.media-list-filters-input {
+  width: 100%;
+
+  .mat-mdc-form-field-flex {
+    height: 40px;
+  }
+
+  .mdc-text-field--outlined {
+    --mdc-outlined-text-field-container-shape: 8px;
+  }
+
+  mat-icon.mat-icon {
+    color: #9e9e9e;
+    font-size: 1em;
+  }
 }
 
 .media-types-checkboxes-container {
   margin-bottom: 1em;
 }
 
-.media-list-placeholder-icon {
-  font-size: 60px;
-  margin-top: 10px;
-  color: #9e9e9e;
-  height: 80px;
+.media-list-item {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid #e2e8ec;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
   width: 100%;
+  background: #fff;
+  transition: box-shadow 0.15s, border-color 0.15s, transform 0.1s;
+
+  &:hover {
+    border-color: #c8d0d8;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  }
 }
 
 .imageContainer {
-  width: 80px;
-  height: 80px;
+  width: 72px;
+  height: 72px;
   overflow: hidden;
   position: relative;
+  border-radius: 10px;
+  flex-shrink: 0;
+  background: #f5f5f5;
 }
 
 .imageCenterer {
@@ -35,42 +75,70 @@
 }
 
 .imageCenterer img {
-  height: 80px;
+  height: 72px;
   display: block;
   margin: 0 auto;
+  border-radius: 10px;
+}
+
+.media-list-placeholder-icon {
+  font-size: 32px;
+  color: #c0c0c0;
+  height: 72px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .media-details {
   text-align: start;
-  margin-top: -18px;
+  margin-left: 14px;
+  flex: 1;
+  min-width: 0;
 }
 
 .media-details-name {
-  @extend .media-details;
-  margin-top: -8px;
-}
-
-.media-details-location {
-  @extend .media-details;
-  font-weight: 300;
+  font-size: 14px;
+  font-weight: 500;
+  color: #2d3748;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 2px;
 }
 
 .media-details-artist {
-  @extend .media-details;
   font-size: 12px;
-  font-weight: 200;
+  font-weight: 400;
+  color: #718096;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.media-details-location {
+  font-size: 11px;
+  font-weight: 300;
+  color: #a0aec0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
 }
 
 .media-details-date {
-  @extend .media-details;
-  font-size: 12px;
-  font-weight: 100;
+  font-size: 11px;
+  font-weight: 300;
+  color: #a0aec0;
+  display: inline;
 }
 
 .media-details-duration {
-  @extend .media-details;
-  font-size: 12px;
-  font-weight: 100;
+  font-size: 11px;
+  font-weight: 300;
+  color: #a0aec0;
+  display: inline;
 }
 
 .media-list-filters-input {

--- a/src/app/components/video-player-drive-iframe/video-player-drive-iframe.component.scss
+++ b/src/app/components/video-player-drive-iframe/video-player-drive-iframe.component.scss
@@ -1,6 +1,10 @@
 .video-iframe-container {
   position: relative;
   padding-bottom: 56.25%;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  border: 1px solid #e0e0e0;
 }
 
 .video-iframe {
@@ -9,10 +13,14 @@
   left: 0;
   width: 100%;
   height: 100%;
+  border-radius: 12px;
 }
 
 .share-video-to-clipboard {
   position: absolute;
-  top: 3px;
-  right: 3px;
+  top: 12px;
+  right: 12px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 8px;
+  padding: 4px 8px;
 }

--- a/src/app/components/video-player-videogular/video-player-videogular.component.scss
+++ b/src/app/components/video-player-videogular/video-player-videogular.component.scss
@@ -1,14 +1,16 @@
 .video-player-container {
-  margin: 1%;
-  width: 98%;
+  margin: 16px 0;
+  width: 100%;
 }
 
 .videogular-container {
   width: 100%;
   height: 320px;
   margin: auto;
-  margin-top: 20%;
   overflow: hidden;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  border: 1px solid #e0e0e0;
 }
 
 .video-player-scrub-bar {
@@ -17,21 +19,21 @@
 
 @media (min-width: 1200px) {
   .videogular-container {
-    width: 1170px;
+    max-width: 1170px;
     height: 658.125px;
   }
 }
 
 @media (min-width: 992px) and (max-width: 1199px) {
   .videogular-container {
-    width: 940px;
+    max-width: 940px;
     height: 528.75px;
   }
 }
 
 @media (min-width: 768px) and (max-width: 991px) {
   .videogular-container {
-    width: 728px;
+    max-width: 728px;
     height: 409.5px;
   }
 }

--- a/src/app/config/feature-config.ts
+++ b/src/app/config/feature-config.ts
@@ -8,11 +8,11 @@ export interface FeatureConfig {
 export const FEATURES: FeatureConfig[] = [
   { id: 'people', label: 'People', route: '/people', icon: 'people' },
   { id: 'contacts', label: 'Contacts', route: '/contacts', icon: 'people' },
-  { id: 'expressions', label: 'Expressions', route: '/expressions', icon: 'format_quote' },
+  { id: 'calendar', label: 'Calendar', route: '/calendar', icon: 'calendar_today' },
   { id: 'music', label: 'Music', route: '/media/audio', icon: 'library_music' },
   { id: 'videos', label: 'Videos', route: '/media/video', icon: 'local_movies' },
-  { id: 'calendar', label: 'Calendar', route: '/calendar', icon: 'calendar_today' },
   { id: 'photos', label: 'Photos', route: '/photos', icon: 'photo' },
+  { id: 'expressions', label: 'Expressions', route: '/expressions', icon: 'format_quote' },
   { id: 'chat', label: 'Chat', route: '/chat', icon: 'message' },
 ];
 

--- a/src/app/services/calendar.service.ts
+++ b/src/app/services/calendar.service.ts
@@ -61,7 +61,7 @@ export class CalendarService {
       if (person.anniversaryDate) {
         const spouse = people.find(p => p.id === person.spouseId);
         const title = spouse
-          ? `${this.getPersonFullName(person)} & ${this.getPersonFullName(spouse)}`
+          ? this.getAnniversaryTitle(person, spouse)
           : this.getPersonFullName(person);
 
         const event = new RecurringEvent();
@@ -84,6 +84,21 @@ export class CalendarService {
     const first = person.name.firstPreferred || person.name.firstGiven || '';
     const last = person.name.last || '';
     return `${first} ${last}`.trim();
+  }
+
+  private getPersonFirstName(person: Person): string {
+    return person.name.firstPreferred || person.name.firstGiven || '';
+  }
+
+  private getAnniversaryTitle(person: Person, spouse: Person): string {
+    const personName = this.getPersonFullName(person);
+    if (!spouse) return personName;
+
+    const sameLastName = person.name.last === spouse.name.last && person.name.last;
+    if (sameLastName) {
+      return `${this.getPersonFirstName(person)} & ${this.getPersonFirstName(spouse)} ${sameLastName}`;
+    }
+    return `${personName} & ${this.getPersonFullName(spouse)}`;
   }
 
   getEventsByPerson(personId: string): Observable<RecurringEvent[]> {

--- a/src/app/services/feature-flags.service.ts
+++ b/src/app/services/feature-flags.service.ts
@@ -55,4 +55,15 @@ export class FeatureFlagsService {
       return flag === null || flag === undefined || flag.enabled === true;
     });
   }
+
+  getPromotedRoute(): Observable<string | null> {
+    return this.db.object('promotedRoute').valueChanges() as Observable<string | null>;
+  }
+
+  setPromotedRoute(route: string): Promise<void> {
+    return this.db.object('promotedRoute').set({
+      route,
+      updatedAt: Date.now(),
+    });
+  }
 }

--- a/src/app/services/routing.service.ts
+++ b/src/app/services/routing.service.ts
@@ -1,12 +1,32 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
 import { environment } from 'src/environments/environment';
+import { FeatureFlagsService } from 'src/app/services/feature-flags.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class RoutingService {
-  constructor(private router: Router, private activatedRoute: ActivatedRoute) {}
+  private promotedRouteSubject = new BehaviorSubject<string | null>(null);
+
+  constructor(
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private featureFlagsService: FeatureFlagsService
+  ) {
+    this.loadPromotedRoute();
+  }
+
+  private loadPromotedRoute(): void {
+    this.featureFlagsService.getPromotedRoute().subscribe((data: any) => {
+      if (data && data.route) {
+        this.promotedRouteSubject.next(data.route);
+      } else {
+        this.promotedRouteSubject.next(environment.promotedRoute || '/');
+      }
+    });
+  }
 
   IsRootRoute() {
     return this.router.url === '/';
@@ -17,8 +37,8 @@ export class RoutingService {
   }
 
   NavigateToPromotedRoute() {
-    const promotedRoute = environment.promotedRoute || '/';
-    this.NavigateToRoute(promotedRoute);
+    const route = this.promotedRouteSubject.getValue() || environment.promotedRoute || '/';
+    this.NavigateToRoute(route);
   }
 
   NavigateToSignIn() {


### PR DESCRIPTION
## Summary
- Redesign Expressions page with modern card styling and green accent border
- Remove comment/edit toolbar from expressions, admin-only edit
- Add skeleton loading state in place of spinner
- Add Promoted Route feature in Admin Features for default landing page
- Polish Video and Media List page styling with rounded corners and shadows
- Style media list items as polished cards with hover effects
- Restyle calendar with updated breakpoint (1350px) for horizontal scrollbar
- Reorder navbar: calendar after contacts, expressions after photos
- Add logic to deduplicate last name in anniversary titles
- Remove Overview from admin sidebar

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>